### PR TITLE
Move all dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "node": ">= 0.6.0"
   },
   "dependencies": {
+  },
+  "devDependencies": {
+    "mocha": "*",
     "colors": "0.5.x",
     "commander": "",
     "request": "*",
@@ -15,10 +18,6 @@
     "uglify-js": "",
     "js-yaml": "",
     "should": "~2.1.0"
-  },
-  "devDependencies": {
-    "mocha": "*",
-    "should": "*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
to prevent them from being unnecessary installed by `npm`